### PR TITLE
Make compatible with .pgpass file

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -8,7 +8,7 @@ import sys
 import os
 
 
-def connect_to_redshift(dbname, host, user, password, port = 5439):
+def connect_to_redshift(dbname, host, user, port = 5439, **kwargs):
     # connect to redshift
     global connect
     global cursor
@@ -16,7 +16,7 @@ def connect_to_redshift(dbname, host, user, password, port = 5439):
                                         host = host,
                                         port = port,
                                         user = user,
-                                        password = password)
+                                        **kwargs)
 
     cursor = connect.cursor()
 


### PR DESCRIPTION
It's useful to store passwords in a `.pgpass` file so that they aren't stored in code. The way the `connect_to_redshift` function is currently written, it requires that a password be explicitly passed to it. This makes it impossible to use a `.pgpass` file, which is only checked when a password isn't provided to the `psycopg2.connect` method.

This PR makes `password` an optional argument to `connect_to_redshift`. It doesn't affect the examples in the documentation, which remain correct.