### PR TITLE
update for name change on psycopg2 wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email = 'aidangawronski@gmail.com',
     # url = 'https://github.com/agawronski/pandas_redshift',
     python_requires = '>=3',
-    install_requires = ['psycopg2',
+    install_requires = ['psycopg2-binary',
                         'pandas',
                         'boto3'],
     include_package_data = True


### PR DESCRIPTION
Update package name to prevent issues & warning : 



UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.