### PR TITLE
Refactor pandas_to_redshift() 

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -47,102 +47,141 @@ def redshift_to_pandas(sql_query):
     return data
 
 
+def validate_column_names(data_frame):
+    """Validate the column names to ensure no reserved words are used.
+
+    Arguments:
+        dataframe pd.data_frame -- data to validate
+    """
+    rrwords = open(os.path.join(os.path.dirname(__file__),
+                                'redshift_reserve_words.txt'), 'r').readlines()
+    rrwords = [r.strip().lower() for r in rrwords]
+
+    data_frame.columns = [x.lower() for x in data_frame.columns]
+
+    for col in data_frame.columns:
+        try:
+            assert col not in rrwords
+        except:
+            raise ValueError(
+                'DataFrame column name {0} is a reserve word in redshift'
+                .format(col))
+
+    return data_frame
+
+
+def df_to_s3(data_frame, csv_name, index, save_local, delimiter):
+    """Write a dataframe to S3
+
+    Arguments:
+        dataframe pd.data_frame -- data to upload
+        csv_name str -- name of the file to upload
+        save_local bool -- save a local copy
+        delimiter str -- delimiter for csv file
+    """
+    # create local backup
+    if save_local == True:
+        data_frame.to_csv(csv_name, index=index, sep=delimiter)
+        print('saved file {0} in {1}'.format(csv_name, os.getcwd()))
+    #
+    csv_buffer = StringIO()
+    data_frame.to_csv(csv_buffer, index=index, sep=delimiter)
+    s3.Bucket(s3_bucket_var).put_object(
+        Key=s3_subdirectory_var + csv_name, Body=csv_buffer.getvalue())
+    print('saved file {0} in bucket {1}'.format(
+        csv_name, s3_subdirectory_var + csv_name))
+
+
+def create_redshift_table(data_frame,
+                          redshift_table_name,
+                          column_data_types=None,
+                          index=False,
+                          append=False):
+    """Create an empty RedShift Table
+
+    """
+    if index == True:
+        columns = list(data_frame.columns)
+        if data_frame.index.name:
+            columns.insert(0, data_frame.index.name)
+        else:
+            columns.insert(0, "index")
+    else:
+        columns = list(data_frame.columns)
+    if column_data_types is None:
+        column_data_types = ['varchar(256)'] * len(columns)
+    columns_and_data_type = ', '.join(
+        ['{0} {1}'.format(x, y) for x, y in zip(columns, column_data_types)])
+    
+    create_table_query = 'create table {0} ({1})'.format(
+        redshift_table_name, columns_and_data_type)
+    print(create_table_query)
+    print('CREATING A TABLE IN REDSHIFT')
+    cursor.execute('drop table if exists {0}'.format(redshift_table_name))
+    cursor.execute(create_table_query)
+    connect.commit()
+
+
+def s3_to_redshift(redshift_table_name, delimiter=',', quotechar='"',
+                   dateformat='auto', timeformat='auto', region=''):
+
+    bucket_name = 's3://{0}/{1}.csv'.format(
+                        s3_bucket_var, s3_subdirectory_var + redshift_table_name)
+    s3_to_sql = """
+    copy {0}
+    from '{1}'
+    delimiter '{2}'
+    ignoreheader 1
+    csv quote as '{3}'
+    dateformat '{4}'
+    timeformat '{5}'
+    access_key_id '{6}'
+    secret_access_key '{7}'
+    """.format(redshift_table_name, bucket_name, delimiter, quotechar, dateformat,
+               timeformat, aws_1, aws_2)
+    if region:
+        s3_to_sql = s3_to_sql + "region '{0}'".format(region)
+    if aws_token != '':
+        s3_to_sql = s3_to_sql + "\n\tsession_token '{0}'".format(aws_token)
+    s3_to_sql = s3_to_sql + ';'
+    print(s3_to_sql)
+    # send the file
+    print('FILLING THE TABLE IN REDSHIFT')
+    try:
+        cursor.execute(s3_to_sql)
+        connect.commit()
+    except Exception as e:
+        print(e)
+        traceback.print_exc(file=sys.stdout)
+        connect.rollback()
+        raise
+
+
 def pandas_to_redshift(data_frame,
                        redshift_table_name,
-                       column_data_types = None,
-                       index = False,
-                       save_local = False,
-                       delimiter = ',',
-                       quotechar = '"',
-                       dateformat = 'auto',
-                       timeformat = 'auto',
-                       region = '',
-                       append = False,
-                       diststyle = 'even',
-                       distkey = '',
-                       sort_interleaved = False,
-                       sortkey = '',
-                      **kwargs):
-    rrwords = open(os.path.join(os.path.dirname(__file__), \
-    'redshift_reserve_words.txt'), 'r').readlines()
-    rrwords = [r.strip().lower() for r in rrwords]
-    accepted_kwargs = ['ACL', 'Body', 'CacheControl ',  'ContentDisposition', 'ContentEncoding', 'ContentLanguage', 'ContentLength', 'ContentMD5', 'ContentType', 'Expires', 'GrantFullControl', 'GrantRead', 'GrantReadACP', 'GrantWriteACP', 'Metadata', 'ServerSideEncryption', 'StorageClass', 'WebsiteRedirectLocation', 'SSECustomerAlgorithm', 'SSECustomerKey', 'SSECustomerKeyMD5', 'SSEKMSKeyId', 'RequestPayer', 'Tagging' ] # Available parameters for service: https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_object
-    extra_kwargs = {k: v for k, v in kwargs.items() if k in accepted_kwargs and v is not None}
-    data_frame.columns = [x.lower() for x in data_frame.columns]
-    not_valid = [r for r in data_frame.columns if r in rrwords]
-    if not_valid:
-        raise ValueError('DataFrame column name {0} is a reserve word in redshift'.format(not_valid[0]))
-    else:
-        csv_name = redshift_table_name + '.csv'
-        if save_local == True:
-            data_frame.to_csv(csv_name, index = index, sep = delimiter)
-            print('saved file {0} in {1}'.format(csv_name, os.getcwd()))
-        # SEND DATA TO S3
-        csv_buffer = StringIO()
-        data_frame.to_csv(csv_buffer, index = index, sep = delimiter)
-        s3.Bucket(s3_bucket_var).put_object(Key= s3_subdirectory_var + csv_name, Body = csv_buffer.getvalue(), **extra_kwargs )
-        print('saved file {0} in bucket {1}'.format(csv_name, s3_subdirectory_var + csv_name))
-        # CREATE AN EMPTY TABLE IN REDSHIFT
-        if index == True:
-            columns = list(data_frame.columns)
-            if data_frame.index.name:
-                columns.insert(0, data_frame.index.name)
-            else:
-                columns.insert(0, "index")
-        else:
-            columns = list(data_frame.columns)
-        if column_data_types is None:
-            column_data_types = ['varchar(256)'] * len(columns)
-        columns_and_data_type = ', '.join(['{0} {1}'.format(x, y) for x,y in zip(columns, column_data_types)])
-        if append is False:
-            create_table_query = 'create table {0} ({1})'.format(redshift_table_name, columns_and_data_type)
-            if len(distkey) == 0:
-                # Without a distkey, we can set a diststyle
-                if diststyle not in ['even', 'all']:
-                    raise ValueError("diststyle must be either 'even' or 'all'")
-                else:
-                    create_table_query += ' diststyle {0}'.format(diststyle)
-            else:
-                # otherwise, override diststyle with distkey
-                create_table_query += ' distkey({0})'.format(distkey)
-            if len(sortkey) > 0:
-                if sort_interleaved:
-                    create_table_query += ' interleaved'
-                create_table_query += ' sortkey({0})'.format(sortkey)
-            print(create_table_query)
-            print('CREATING A TABLE IN REDSHIFT')
-            cursor.execute('drop table if exists {0}'.format(redshift_table_name))
-            cursor.execute(create_table_query)
-            connect.commit()
-        # CREATE THE COPY STATEMENT TO SEND FROM S3 TO THE TABLE IN REDSHIFT
-        bucket_name = 's3://{0}/{1}'.format(s3_bucket_var, s3_subdirectory_var + csv_name)
-        s3_to_sql = """
-        copy {0}
-        from '{1}'
-        delimiter '{2}'
-        ignoreheader 1
-        csv quote as '{3}'
-        dateformat '{4}'
-        timeformat '{5}'
-        access_key_id '{6}'
-        secret_access_key '{7}'
-        """.format(redshift_table_name, bucket_name, delimiter, quotechar, dateformat, timeformat, aws_1, aws_2)
-        if region:
-            s3_to_sql = s3_to_sql +  "region '{0}'".format(region)
-        if aws_token != '':
-            s3_to_sql = s3_to_sql +  "\n\tsession_token '{0}'".format(aws_token)
-        s3_to_sql = s3_to_sql + ';'
-        print(s3_to_sql)
-        # send the file
-        print('FILLING THE TABLE IN REDSHIFT')
-        try:
-            cursor.execute(s3_to_sql)
-            connect.commit()
-        except Exception as e:
-            print(e)
-            traceback.print_exc(file=sys.stdout)
-            connect.rollback()
-            raise
+                       column_data_types=None,
+                       index=False,
+                       save_local=False,
+                       delimiter=',',
+                       quotechar='"',
+                       dateformat='auto',
+                       timeformat='auto',
+                       region='',
+                       append=False):
+
+    # Validate column names.
+    data_frame = validate_column_names(data_frame)
+    # Send data to S3
+    csv_name = redshift_table_name + '.csv'
+    df_to_s3(data_frame, csv_name, index, save_local, delimiter)
+
+    # CREATE AN EMPTY TABLE IN REDSHIFT
+    if append is False:
+        create_redshift_table(data_frame, redshift_table_name,
+                              column_data_types, index, append)
+    # CREATE THE COPY STATEMENT TO SEND FROM S3 TO THE TABLE IN REDSHIFT
+    s3_to_redshift(redshift_table_name, delimiter, quotechar,
+                   dateformat, timeformat, region)
 
 
 


### PR DESCRIPTION
refactor pandas_to_redshift into multiple functions, so that each function performs one of the steps involved in the current function and they can be called and tested independently. 
The goal of this change is to simplify the function, improve readability and enable users to call independent steps if necessary. Could also facilitate implementation of a class object for the library. 


Should not affect core functionality
Also add a few docstrings.