### PR TITLE
Improve SQL data types and fix parallel issue

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -10,19 +10,20 @@ import re
 
 S3_ACCEPTED_KWARGS = [
     'ACL', 'Body', 'CacheControl ',  'ContentDisposition', 'ContentEncoding', 'ContentLanguage',
-    'ContentLength', 'ContentMD5', 'ContentType', 'Expires', 'GrantFullControl', 'GrantRead', 
-    'GrantReadACP', 'GrantWriteACP', 'Metadata', 'ServerSideEncryption', 'StorageClass', 
-    'WebsiteRedirectLocation', 'SSECustomerAlgorithm', 'SSECustomerKey', 'SSECustomerKeyMD5', 
+    'ContentLength', 'ContentMD5', 'ContentType', 'Expires', 'GrantFullControl', 'GrantRead',
+    'GrantReadACP', 'GrantWriteACP', 'Metadata', 'ServerSideEncryption', 'StorageClass',
+    'WebsiteRedirectLocation', 'SSECustomerAlgorithm', 'SSECustomerKey', 'SSECustomerKeyMD5',
     'SSEKMSKeyId', 'RequestPayer', 'Tagging'
-] # Available parameters for service: https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_object
+]  # Available parameters for service: https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_object
 
-def connect_to_redshift(dbname, host, user, port = 5439, **kwargs):
+
+def connect_to_redshift(dbname, host, user, port=5439, **kwargs):
     global connect, cursor
-    connect = psycopg2.connect(dbname = dbname,
-                                        host = host,
-                                        port = port,
-                                        user = user,
-                                        **kwargs)
+    connect = psycopg2.connect(dbname=dbname,
+                               host=host,
+                               port=port,
+                               user=user,
+                               **kwargs)
 
     cursor = connect.cursor()
 
@@ -30,8 +31,8 @@ def connect_to_redshift(dbname, host, user, port = 5439, **kwargs):
 def connect_to_s3(aws_access_key_id, aws_secret_access_key, bucket, subdirectory=None, aws_iam_role=None, **kwargs):
     global s3, s3_bucket_var, s3_subdirectory_var, aws_1, aws_2, aws_token, aws_role
     s3 = boto3.resource('s3',
-                        aws_access_key_id = aws_access_key_id,
-                        aws_secret_access_key = aws_secret_access_key,
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key,
                         **kwargs)
     s3_bucket_var = bucket
     if subdirectory is None:
@@ -51,7 +52,7 @@ def redshift_to_pandas(sql_query):
     # pass a sql query and return a pandas dataframe
     cursor.execute(sql_query)
     columns_list = [desc[0] for desc in cursor.description]
-    data = pd.DataFrame(cursor.fetchall(), columns = columns_list)
+    data = pd.DataFrame(cursor.fetchall(), columns=columns_list)
     return data
 
 
@@ -70,17 +71,18 @@ def validate_column_names(data_frame):
     for col in data_frame.columns:
         try:
             assert col not in rrwords
-        except:
+        except AssertionError:
             raise ValueError(
                 'DataFrame column name {0} is a reserve word in redshift'
                 .format(col))
 
     # check for spaces in the column names
-    there_are_spaces = sum([re.search('\s', x) != None for x in data_frame.columns]) > 0
+    there_are_spaces = sum(
+        [re.search('\s', x) is not None for x in data_frame.columns]) > 0
     # delimit them if there are
     if there_are_spaces:
-        col_names_dict = {x:'"{0}"'.format(x) for x in data_frame.columns}
-        data_frame.rename(columns = col_names_dict, inplace = True)
+        col_names_dict = {x: '"{0}"'.format(x) for x in data_frame.columns}
+        data_frame.rename(columns=col_names_dict, inplace=True)
     return data_frame
 
 
@@ -93,9 +95,10 @@ def df_to_s3(data_frame, csv_name, index, save_local, delimiter, **kwargs):
         save_local bool -- save a local copy
         delimiter str -- delimiter for csv file
     """
-    extra_kwargs = {k: v for k, v in kwargs.items() if k in S3_ACCEPTED_KWARGS and v is not None}
+    extra_kwargs = {k: v for k, v in kwargs.items(
+    ) if k in S3_ACCEPTED_KWARGS and v is not None}
     # create local backup
-    if save_local == True:
+    if save_local:
         data_frame.to_csv(csv_name, index=index, sep=delimiter)
         print('saved file {0} in {1}'.format(csv_name, os.getcwd()))
     #
@@ -115,7 +118,7 @@ def pd_dtype_to_redshift_dtype(dtype):
         return 'REAL'
     elif dtype.startswith('datetime'):
         return 'TIMESTAMP'
-    elif dtype=='bool':
+    elif dtype == 'bool':
         return 'BOOLEAN'
     else:
         return 'VARCHAR(256)'
@@ -135,14 +138,14 @@ def create_redshift_table(data_frame,
                           column_data_types=None,
                           index=False,
                           append=False,
-                          diststyle = 'even',
-                          distkey = '',
-                          sort_interleaved = False,
-                          sortkey = ''):
+                          diststyle='even',
+                          distkey='',
+                          sort_interleaved=False,
+                          sortkey=''):
     """Create an empty RedShift Table
 
     """
-    if index == True:
+    if index:
         columns = list(data_frame.columns)
         if data_frame.index.name:
             columns.insert(0, data_frame.index.name)
@@ -154,10 +157,10 @@ def create_redshift_table(data_frame,
         column_data_types = get_column_data_types(data_frame, index)
     columns_and_data_type = ', '.join(
         ['{0} {1}'.format(x, y) for x, y in zip(columns, column_data_types)])
-    
+
     create_table_query = 'create table {0} ({1})'.format(
         redshift_table_name, columns_and_data_type)
-    if len(distkey) == 0:
+    if not distkey:
         # Without a distkey, we can set a diststyle
         if diststyle not in ['even', 'all']:
             raise ValueError("diststyle must be either 'even' or 'all'")
@@ -181,7 +184,7 @@ def s3_to_redshift(redshift_table_name, delimiter=',', quotechar='"',
                    dateformat='auto', timeformat='auto', region='', parameters=''):
 
     bucket_name = 's3://{0}/{1}.csv'.format(
-                        s3_bucket_var, s3_subdirectory_var + redshift_table_name)
+        s3_bucket_var, s3_subdirectory_var + redshift_table_name)
 
     if aws_1 and aws_2:
         authorization = """
@@ -247,17 +250,18 @@ def pandas_to_redshift(data_frame,
     data_frame = validate_column_names(data_frame)
     # Send data to S3
     csv_name = redshift_table_name + '.csv'
-    s3_kwargs = {k: v for k, v in kwargs.items() if k in S3_ACCEPTED_KWARGS and v is not None}
+    s3_kwargs = {k: v for k, v in kwargs.items(
+    ) if k in S3_ACCEPTED_KWARGS and v is not None}
     df_to_s3(data_frame, csv_name, index, save_local, delimiter, **s3_kwargs)
 
     # CREATE AN EMPTY TABLE IN REDSHIFT
-    if append is False:
+    if not append:
         create_redshift_table(data_frame, redshift_table_name,
                               column_data_types, index, append,
                               diststyle, distkey, sort_interleaved, sortkey)
     # CREATE THE COPY STATEMENT TO SEND FROM S3 TO THE TABLE IN REDSHIFT
-    s3_to_redshift(redshift_table_name, delimiter, quotechar, dateformat, timeformat, region, parameters)
-
+    s3_to_redshift(redshift_table_name, delimiter, quotechar,
+                   dateformat, timeformat, region, parameters)
 
 
 def exec_commit(sql_query):
@@ -279,4 +283,4 @@ def close_up_shop():
     except:
         pass
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 from setuptools import setup
 
 setup(
-    name = 'pandas_redshift',
-    packages = ['pandas_redshift'],
-    version = '1.1.3',
-    description = 'Load data from redshift into a pandas DataFrame and vice versa.',
-    author = 'Aidan Gawronski',
-    author_email = 'aidangawronski@gmail.com',
+    name='pandas_redshift',
+    packages=['pandas_redshift'],
+    version='1.1.3',
+    description='Load data from redshift into a pandas DataFrame and vice versa.',
+    author='Aidan Gawronski',
+    author_email='aidangawronski@gmail.com',
     # url = 'https://github.com/agawronski/pandas_redshift',
-    python_requires = '>=3',
-    install_requires = ['psycopg2-binary',
-                        'pandas',
-                        'boto3'],
-    include_package_data = True
+    python_requires='>=3',
+    install_requires=['psycopg2-binary',
+                      'pandas',
+                      'boto3'],
+    include_package_data=True
 )


### PR DESCRIPTION
Improvements:

- improve SQL data types in `func:create_redshift_table`

in currently release, all columns sql data type will mapping to `varchar(256)`
when `column_data_types` parameter not specify, i have update the
column_data_types mappings:

```py
def pd_dtype_to_redshift_dtype(dtype):
    if dtype.startswith('int'):
        return 'INTEGER'
    elif dtype.startswith('float'):
        return 'REAL'
    elif dtype.startswith('datetime'):
        return 'TIMESTAMP'
    elif dtype=='bool':
        return 'BOOLEAN'
    else:
        return 'VARCHAR(256)'
```
-  Fix: Parallel run `pandas_to_redshift` load same s3 file issue
-  PEP8 code style.