### PR TITLE
Fix/infer bigint for int64

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -114,6 +114,8 @@ def df_to_s3(data_frame, csv_name, index, save_local, delimiter, **kwargs):
 
 
 def pd_dtype_to_redshift_dtype(dtype):
+    if dtype.startswith('int64'):
+        return 'BIGINT'
     if dtype.startswith('int'):
         return 'INTEGER'
     elif dtype.startswith('float'):

--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -116,7 +116,7 @@ def df_to_s3(data_frame, csv_name, index, save_local, delimiter, **kwargs):
 def pd_dtype_to_redshift_dtype(dtype):
     if dtype.startswith('int64'):
         return 'BIGINT'
-    if dtype.startswith('int'):
+    elif dtype.startswith('int'):
         return 'INTEGER'
     elif dtype.startswith('float'):
         return 'REAL'


### PR DESCRIPTION
This fix infer the type BIGINT for an int64 column in a pandas dataframe.
Before this, a stl_load_errors entry was made when the int values of the column were outside the range of a Redshift integer (-2147483648 to +2147483647).

This should fix issue #35 