### PR TITLE
Add verbose flag to control print commands

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -262,17 +262,17 @@ def pandas_to_redshift(data_frame,
     csv_name = '{}-{}.csv'.format(redshift_table_name, uuid.uuid4())
     s3_kwargs = {k: v for k, v in kwargs.items()
         if k in S3_ACCEPTED_KWARGS and v is not None}
-    df_to_s3(data_frame, csv_name, index, save_local, delimiter, **s3_kwargs)
+    df_to_s3(data_frame, csv_name, index, save_local, delimiter, verbose=verbose, **s3_kwargs)
 
     # CREATE AN EMPTY TABLE IN REDSHIFT
     if not append:
         create_redshift_table(data_frame, redshift_table_name,
                               column_data_types, index, append,
-                              diststyle, distkey, sort_interleaved, sortkey)
+                              diststyle, distkey, sort_interleaved, sortkey, verbose=verbose)
 
     # CREATE THE COPY STATEMENT TO SEND FROM S3 TO THE TABLE IN REDSHIFT
     s3_to_redshift(redshift_table_name, csv_name, delimiter, quotechar,
-                   dateformat, timeformat, region, parameters)
+                   dateformat, timeformat, region, parameters, verbose=verbose)
 
 
 def exec_commit(sql_query):

--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -102,15 +102,17 @@ def df_to_s3(data_frame, csv_name, index, save_local, delimiter, verbose=True, *
     # create local backup
     if save_local:
         data_frame.to_csv(csv_name, index=index, sep=delimiter)
-        print('saved file {0} in {1}'.format(csv_name, os.getcwd()))
+        if verbose:
+            print('saved file {0} in {1}'.format(csv_name, os.getcwd()))
     #
     csv_buffer = StringIO()
     data_frame.to_csv(csv_buffer, index=index, sep=delimiter)
     s3.Bucket(s3_bucket_var).put_object(
         Key=s3_subdirectory_var + csv_name, Body=csv_buffer.getvalue(),
         **extra_kwargs)
-    print('saved file {0} in bucket {1}'.format(
-        csv_name, s3_subdirectory_var + csv_name))
+    if verbose:
+        print('saved file {0} in bucket {1}'.format(
+            csv_name, s3_subdirectory_var + csv_name))
 
 
 def pd_dtype_to_redshift_dtype(dtype):
@@ -178,8 +180,9 @@ def create_redshift_table(data_frame,
         if sort_interleaved:
             create_table_query += ' interleaved'
         create_table_query += ' sortkey({0})'.format(sortkey)
-    print(create_table_query)
-    print('CREATING A TABLE IN REDSHIFT')
+    if verbose:
+        print(create_table_query)
+        print('CREATING A TABLE IN REDSHIFT')
     cursor.execute('drop table if exists {0}'.format(redshift_table_name))
     cursor.execute(create_table_query)
     connect.commit()
@@ -220,9 +223,10 @@ def s3_to_redshift(redshift_table_name, csv_name, delimiter=',', quotechar='"',
     if aws_token != '':
         s3_to_sql = s3_to_sql + "\n\tsession_token '{0}'".format(aws_token)
     s3_to_sql = s3_to_sql + ';'
-    print(s3_to_sql)
-    # send the file
-    print('FILLING THE TABLE IN REDSHIFT')
+    if verbose:
+        print(s3_to_sql)
+        # send the file
+        print('FILLING THE TABLE IN REDSHIFT')
     try:
         cursor.execute(s3_to_sql)
         connect.commit()

--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -88,7 +88,7 @@ def validate_column_names(data_frame):
     return data_frame
 
 
-def df_to_s3(data_frame, csv_name, index, save_local, delimiter, **kwargs):
+def df_to_s3(data_frame, csv_name, index, save_local, delimiter, verbose=True, **kwargs):
     """Write a dataframe to S3
 
     Arguments:
@@ -145,7 +145,8 @@ def create_redshift_table(data_frame,
                           diststyle='even',
                           distkey='',
                           sort_interleaved=False,
-                          sortkey=''):
+                          sortkey='',
+                          verbose=True):
     """Create an empty RedShift Table
 
     """
@@ -185,7 +186,7 @@ def create_redshift_table(data_frame,
 
 
 def s3_to_redshift(redshift_table_name, csv_name, delimiter=',', quotechar='"',
-                   dateformat='auto', timeformat='auto', region='', parameters=''):
+                   dateformat='auto', timeformat='auto', region='', parameters='', verbose=True):
 
     bucket_name = 's3://{0}/{1}'.format(
         s3_bucket_var, s3_subdirectory_var + csv_name)
@@ -248,6 +249,7 @@ def pandas_to_redshift(data_frame,
                        sort_interleaved=False,
                        sortkey='',
                        parameters='',
+                       verbose=True,
                        **kwargs):
 
     # Validate column names.


### PR DESCRIPTION
**CHANGELOG**
* Add verbose flag to all core methods that have `print` commands
* Set verbose as `True` by default to keep the current behavior

**SUMMARY**
This feature was mentioned here: https://github.com/agawronski/pandas_redshift/issues/38
I am using this project for an API where I work and printing AWS keys on our logs is somewhat a security hazard