### PR TITLE
Redshift table names with special chars

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -165,7 +165,7 @@ def create_redshift_table(data_frame,
     columns_and_data_type = ', '.join(
         ['{0} {1}'.format(x, y) for x, y in zip(columns, column_data_types)])
 
-    create_table_query = 'create table {0} ({1})'.format(
+    create_table_query = 'create table "{0}" ({1})'.format(
         redshift_table_name, columns_and_data_type)
     if not distkey:
         # Without a distkey, we can set a diststyle
@@ -183,7 +183,7 @@ def create_redshift_table(data_frame,
     if verbose:
         print(create_table_query)
         print('CREATING A TABLE IN REDSHIFT')
-    cursor.execute('drop table if exists {0}'.format(redshift_table_name))
+    cursor.execute('drop table if exists "{0}"'.format(redshift_table_name))
     cursor.execute(create_table_query)
     connect.commit()
 
@@ -207,7 +207,7 @@ def s3_to_redshift(redshift_table_name, csv_name, delimiter=',', quotechar='"',
         authorization = ""
 
     s3_to_sql = """
-    copy {0}
+    copy "{0}"
     from '{1}'
     delimiter '{2}'
     ignoreheader 1


### PR DESCRIPTION
Hi, this is an awesome library, really appreciate the work!

I found that the library has some trouble when writing to Redshift tables with special characters in the table name (e.g. "-", ":"). As a fix, I just added double quotes in the drop table, create table, and copy queries around the table name.