### PR TITLE
Revert "Redshift table names with special chars"

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -165,7 +165,7 @@ def create_redshift_table(data_frame,
     columns_and_data_type = ', '.join(
         ['{0} {1}'.format(x, y) for x, y in zip(columns, column_data_types)])
 
-    create_table_query = 'create table "{0}" ({1})'.format(
+    create_table_query = 'create table {0} ({1})'.format(
         redshift_table_name, columns_and_data_type)
     if not distkey:
         # Without a distkey, we can set a diststyle
@@ -183,7 +183,7 @@ def create_redshift_table(data_frame,
     if verbose:
         print(create_table_query)
         print('CREATING A TABLE IN REDSHIFT')
-    cursor.execute('drop table if exists "{0}"'.format(redshift_table_name))
+    cursor.execute('drop table if exists {0}'.format(redshift_table_name))
     cursor.execute(create_table_query)
     connect.commit()
 
@@ -207,7 +207,7 @@ def s3_to_redshift(redshift_table_name, csv_name, delimiter=',', quotechar='"',
         authorization = ""
 
     s3_to_sql = """
-    copy "{0}"
+    copy {0}
     from '{1}'
     delimiter '{2}'
     ignoreheader 1


### PR DESCRIPTION
Reverts agawronski/pandas_redshift#43

This merge caused problems for schema reference and cross-database reference.
Special characters should be instead handled by the user, for example:

```python
pr.pandas_to_redshift(
    data_frame=data,
    redshift_table_name='schema."bad.name"'
)
```

Related issue: https://github.com/agawronski/pandas_redshift/issues/45#issue-590571184