### PR TITLE
updating core.py to address dask-dataframe types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ setup(
     author_email='aidangawronski@gmail.com',
     # url = 'https://github.com/agawronski/pandas_redshift',
     python_requires='>=3',
-    install_requires=['psycopg2-binary',
-                      'pandas',
-                      'boto3'],
+    install_requires=["psycopg2-binary",
+                      "pandas",
+                      "'dask[dataframe]'"
+                      "boto3"],
     include_package_data=True
 )


### PR DESCRIPTION
Updated the core.py script to accept data-frames created using the dask library as opposed pandas; update can be found on the d3_to_s3 function

Dask data frames are an alternative to pandas as it allows for parallel processing of data