### PR TITLE
Add ability to specify the csv filenames in s3

### DIFF
--- a/pandas_redshift/core.py
+++ b/pandas_redshift/core.py
@@ -283,12 +283,14 @@ def pandas_to_redshift(data_frame,
                        sortkey='',
                        parameters='',
                        verbose=True,
+                       csv_name=None,
                        **kwargs):
 
     # Validate column names.
     data_frame = validate_column_names(data_frame)
     # Send data to S3
-    csv_name = '{}-{}.csv'.format(redshift_table_name, uuid.uuid4())
+    if not csv_name:
+        csv_name = '{}-{}.csv'.format(redshift_table_name, uuid.uuid4())
     s3_kwargs = {k: v for k, v in kwargs.items()
         if k in S3_ACCEPTED_KWARGS and v is not None}
     df_to_s3(data_frame, csv_name, index, save_local, delimiter, verbose=verbose, **s3_kwargs)


### PR DESCRIPTION
Made csv_name an optional parameter of pandas_to_redshift().  Default is None, in which case the current name format will be used.  Otherwise, it will use the name passed in.